### PR TITLE
Import six for compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ from your ``Django`` app.
 Prerequisites
 =============
 - Python: 2.7, 3.5 and 3.6
-- Django: 1.8, 1.9, 1.10, 1.11, 2.0, 2.1 and 2.2
+- Django: 1.8, 1.9, 1.10, 1.11, 2.0, 2.1, 2.2 and 3.2
 
 Installation
 ============
@@ -38,6 +38,12 @@ Installation
             'emailtools',
             # ...
         )
+
+3.  Install Six
+
+    .. code-block:: sh
+
+        pip install six
 
 Testing
 =======

--- a/emailtools/cbe/__init__.py
+++ b/emailtools/cbe/__init__.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage, EmailMultiAlternatives
 from django.template import loader
-from django.utils import six
+import six
 from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
 

--- a/tests/tests/settings.py
+++ b/tests/tests/settings.py
@@ -20,7 +20,7 @@ INSTALLED_APPS = (
 
 DEBUG_TEMPLATE = False
 
-if DJANGO_VERSION[:2] in ((1, 10), (1, 11), (2, 0), (2, 1), (2, 2)):
+if DJANGO_VERSION[:2] in ((1, 10), (1, 11), (2, 0), (2, 1), (2, 2), (3, 2)):
     TEMPLATES = [
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
django.utils.six was deprecated from Django 2.0 onward.  Import Six library instead for compatibility.